### PR TITLE
Upgrade clipboard-win to 4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,4 @@ edition = "2018"
 [dependencies]
 docopt = "1.1.0"
 serde = { version = "1", features = ["derive"] }
-clipboard-win = "1.7"
-user32-sys = "0.2"
-kernel32-sys = "0.2"
-windows-error = "1.0"
+clipboard-win = "4"


### PR DESCRIPTION
Upgrade `clipboard-win` to 4, mostly sticking to the same logic as before.

I realized after doing this that there is an existing PR which sticks to the simplified APIs from `clipboard-win`. Not sure if there is a style preference, modulo whether or not tests pass.

I use this with `neovim` in `wsl2` and it works fine for me.